### PR TITLE
fix: [#18] 아티클이 패딩 없이 모바일 화면에 꽉 차는 버그

### DIFF
--- a/src/components/Article/index.tsx
+++ b/src/components/Article/index.tsx
@@ -13,7 +13,7 @@ function Article({ article }: Props) {
   }
 
   return (
-    <article className="prose break-word w-screen">
+    <article className="prose break-word w-full prose-a:break-all ">
       <ReactMarkdown remarkPlugins={[reamarkGfm]}>{article.data}</ReactMarkdown>
     </article>
   );

--- a/src/components/MainContent/index.tsx
+++ b/src/components/MainContent/index.tsx
@@ -95,7 +95,7 @@ function MainContent({
     );
   }
   return (
-    <main className="flex flex-1 w-screen justify-center pt-6 lg:pt-14 pb-6 px-6 lg:px-8">
+    <main className="flex flex-1 w-full justify-center pt-6 lg:pt-14 pb-6 px-6 lg:px-8">
       {currentNode.type === 'tree' ? (
         <ArticleList articles={articles} />
       ) : (

--- a/src/pages/Repository/index.tsx
+++ b/src/pages/Repository/index.tsx
@@ -282,7 +282,7 @@ function Repository() {
     return <Navigate to={'/404-not-found'} replace={true} />;
   }
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex w-full flex-col h-screen">
       <Header openSidebar={openSidebar} branchInfo={branchInfo} />
       <div className="flex grow">
         <Sidebar


### PR DESCRIPTION
* 아티클 컴포넌트에 w-full을, 모든 부모 컴포넌트에도 w-full을 적용하여 해결